### PR TITLE
Remove unused code

### DIFF
--- a/src/ioq_sup.erl
+++ b/src/ioq_sup.erl
@@ -13,7 +13,6 @@
 -module(ioq_sup).
 -behaviour(supervisor).
 -export([start_link/0, init/1]).
--export([handle_config_change/5, handle_config_terminate/3]).
 
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 5000, Type, [I]}).
@@ -22,24 +21,4 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    {ok, { {one_for_one, 5, 10}, [
-        {
-            config_listener_mon,
-            {config_listener_mon, start_link, [?MODULE, nil]},
-            permanent,
-            5000,
-            worker,
-            [config_listener_mon]
-        },
-        ?CHILD(ioq, worker)
-    ]} }.
-
-handle_config_change("ioq", _Key, _Val, _Persist, St) ->
-    gen_server:cast(ioq_server, update_config),
-    {ok, St};
-handle_config_change(_Sec, _Key, _Val, _Persist, St) ->
-    {ok, St}.
-
-handle_config_terminate(_Server, _Reason, _State) ->
-    gen_server:cast(ioq_server, update_config),
-    ok.
+    {ok, { {one_for_one, 5, 10}, [?CHILD(ioq, worker)]}}.


### PR DESCRIPTION
We are subscribing both [ioq](https://github.com/apache/couchdb-ioq/blob/master/src/ioq.erl#L54) and [ioq_sup](https://github.com/apache/couchdb-ioq/blob/master/src/ioq_sup.erl#L28) to config_event, but while `ioq` is actually processes config changes, `ioq_sup` just sends uncatched messages to unexisting `ioq_server`.

I assume this is an artifact of config event rewiring and a mix-up on the different versions of ioq.