### PR TITLE
Reconfigure IOQ on config update

### DIFF
--- a/src/ioq_sup.erl
+++ b/src/ioq_sup.erl
@@ -12,11 +12,16 @@
 
 -module(ioq_sup).
 -behaviour(supervisor).
+-vsn(1).
+-behaviour(config_listener).
 -export([start_link/0, init/1]).
 -export([get_ioq2_servers/0]).
+-export([handle_config_change/5, handle_config_terminate/3]).
+-export([processes/1]).
 
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 5000, Type, [I]}).
+-define(CHILD_WITH_ARGS(I, Type, Args), {I, {I, start_link, Args}, permanent, 5000, Type, [I]}).
 
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
@@ -27,6 +32,7 @@ init([]) ->
     {ok, {
         {one_for_one, 5, 10},
         [
+            ?CHILD_WITH_ARGS(config_listener_mon, worker, [?MODULE, nil]),
             ?CHILD(ioq_server, worker),
             ?CHILD(ioq_osq, worker)
             | IOQ2Children
@@ -47,3 +53,42 @@ get_ioq2_servers() ->
     lists:map(fun(I) ->
         list_to_atom("ioq_server_" ++ integer_to_list(I))
     end, lists:seq(1, erlang:system_info(schedulers))).
+
+handle_config_change("ioq", _Key, _Val, _Persist, St) ->
+    gen_server:cast(ioq_server, update_config),
+    {ok, St};
+handle_config_change("ioq2" ++ _, _Key, _Val, _Persist, St) ->
+    lists:foreach(fun({_Id, Pid}) ->
+        gen_server:call(Pid, update_config)
+    end, processes(ioq2)),
+    {ok, St};
+handle_config_change(_Sec, _Key, _Val, _Persist, St) ->
+    {ok, St}.
+
+handle_config_terminate(_Server, _Reason, _State) ->
+    gen_server:cast(ioq_server, update_config),
+    spawn(fun() ->
+        lists:foreach(fun({_Id, Pid}) ->
+            gen_server:call(Pid, update_config)
+        end, processes(ioq2))
+    end),
+    ok.
+
+processes(ioq2) ->
+    filter_children("^ioq_server_.*$");
+processes(ioq) ->
+    filter_children("^ioq_server$");
+processes(config_listener_mon) ->
+    filter_children("^config_listener_mon$");
+processes(Arg) ->
+    {error, [
+        {expected_one_of, [ioq, ioq2, config_listener_mon]},
+        {got, Arg}]}.
+
+filter_children(RegExp) ->
+    lists:filtermap(fun({Id, P, _, _}) ->
+        case re:run(atom_to_list(Id), RegExp) of
+            {match, _} -> {true, {Id, P}};
+            _ -> false
+        end
+    end, supervisor:which_children(?MODULE)).


### PR DESCRIPTION
Previously updating options used by ioq server processes require manual calls:
- `gen_server:cast(ioq_server, update_config)`
- `ioq_server2:update_config()` - which only works for first process

This PR adds automatic reload of updated configuration in following cases:
- configuration option in `ioq` section is updated
- configuration option in any of the sections matching `ioq2.*` is updated
- config listener restarts