### PR TITLE
Use cast to send `update_config` to `ioq2`

### DIFF
--- a/src/ioq_sup.erl
+++ b/src/ioq_sup.erl
@@ -59,7 +59,7 @@ handle_config_change("ioq", _Key, _Val, _Persist, St) ->
     {ok, St};
 handle_config_change("ioq2" ++ _, _Key, _Val, _Persist, St) ->
     lists:foreach(fun({_Id, Pid}) ->
-        gen_server:call(Pid, update_config)
+        gen_server:cast(Pid, update_config)
     end, processes(ioq2)),
     {ok, St};
 handle_config_change(_Sec, _Key, _Val, _Persist, St) ->
@@ -69,7 +69,7 @@ handle_config_terminate(_Server, _Reason, _State) ->
     gen_server:cast(ioq_server, update_config),
     spawn(fun() ->
         lists:foreach(fun({_Id, Pid}) ->
-            gen_server:call(Pid, update_config)
+            gen_server:cast(Pid, update_config)
         end, processes(ioq2))
     end),
     ok.


### PR DESCRIPTION
Switch to `gen_server:cast/2` for `ioq2` since it [supports it here](https://github.com/apache/couchdb-ioq/blob/master/src/ioq_server2.erl#L324).