### PR TITLE
Start couch_log in tests

### DIFF
--- a/test/ioq_config_tests.erl
+++ b/test/ioq_config_tests.erl
@@ -35,7 +35,7 @@ config_update_test_() ->
         "Test config updates",
         {
             foreach,
-            fun() -> test_util:start_applications([config, ioq]) end,
+            fun() -> test_util:start_applications([config, couch_log, ioq]) end,
             fun test_util:stop_applications/1,
             [
                 fun t_restart_config_listener/1,


### PR DESCRIPTION
The `config` app needs `couch_log` application to be running.

# Testing recommendation
```
make eunit apps=ioq
```
