### PR TITLE
Allow for dynamic ioq classes

### DIFF
--- a/IOQ2.md
+++ b/IOQ2.md
@@ -611,6 +611,16 @@ You can see the proper names for all registered IOQ classes with the following:
 ```
 
 
+### Dynamic IOQ classes
+
+To support 3rd party IO channels for things like search/geo/cache/etc, you can
+manually set a config priority for the desired class, and then it will be
+picked up by `ioq_config:is_valid_class/1`. Because the `ioq_config:set_*`
+setters depend on `is_valid_class`, you must manually define the priority
+initially, for example with `config:set("ioq.classes", "search", "1.0").`.
+Afterwards, you'll be able to utilize the setters as expected.
+
+
 ## ioq_server2:get_state
 
 You can see a human readable representation of the IOQ2 server state with the

--- a/include/ioq.hrl
+++ b/include/ioq.hrl
@@ -19,6 +19,15 @@
 -define(DISPATCH_SINGLE_SERVER, "single_server").
 -define(DISPATCH_SERVER_PER_SCHEDULER, "server_per_scheduler").
 
+%% Config Categories
+-define(SHARD_CLASS_SEPARATOR, "||").
+-define(IOQ2_CONFIG, "ioq2").
+-define(IOQ2_BYPASS_CONFIG, "ioq2.bypass").
+-define(IOQ2_SHARDS_CONFIG, "ioq2.shards").
+-define(IOQ2_USERS_CONFIG, "ioq2.users").
+-define(IOQ2_CLASSES_CONFIG, "ioq2.classes").
+
+
 -define(DEFAULT_CLASS_PRIORITIES, [
     {customer, 1.0},
     {internal_repl, 0.001},

--- a/src/ioq_config.erl
+++ b/src/ioq_config.erl
@@ -54,14 +54,6 @@
 ]).
 
 
--define(SHARD_CLASS_SEPARATOR, "||").
--define(IOQ2_CONFIG, "ioq2").
--define(IOQ2_BYPASS_CONFIG, "ioq2.bypass").
--define(IOQ2_SHARDS_CONFIG, "ioq2.shards").
--define(IOQ2_USERS_CONFIG, "ioq2.users").
--define(IOQ2_CLASSES_CONFIG, "ioq2.classes").
-
-
 ioq_classes() ->
     [Class || {Class, _Priority} <- ?DEFAULT_CLASS_PRIORITIES].
 

--- a/src/ioq_config.erl
+++ b/src/ioq_config.erl
@@ -135,8 +135,19 @@ set_user_config(User, Value, Reason) ->
     ok = set_config(?IOQ2_USERS_CONFIG, User, Value, Reason).
 
 
-is_valid_class(Class) ->
-    lists:member(Class, ioq_classes()).
+is_valid_class(Class) when is_atom(Class) ->
+    case lists:member(Class, ioq_classes()) of
+        true ->
+            true;
+        false ->
+            SClass = atom_to_list(Class),
+            case config:get(?IOQ2_CLASSES_CONFIG, SClass, undefined) of
+                undefined ->
+                    false;
+                _ ->
+                    true
+            end
+    end.
 
 
 check_float_value(Value) when is_float(Value) ->

--- a/test/ioq_config_tests.erl
+++ b/test/ioq_config_tests.erl
@@ -260,3 +260,34 @@ check_bypass_configs(_) ->
     ok = ioq_config:set_bypass(interactive, true, "Bypassing interactive"),
     Value = config:get_boolean("ioq2.bypass", "interactive", false),
     ?_assertEqual(true, Value).
+
+
+valid_classes_test_() ->
+    {
+        "Test ioq_config is_valid_class logic",
+        {
+            foreach,
+            fun() -> test_util:start_applications([config, couch_log]) end,
+            fun(_) -> test_util:stop_applications([config, couch_log]) end,
+            [
+                fun check_default_classes/1,
+                fun check_undeclared_class/1,
+                fun check_declared_class/1
+            ]
+        }
+    }.
+
+
+check_default_classes(_) ->
+    Classes = [C || {C, _P} <- ?DEFAULT_CLASS_PRIORITIES],
+    [?_assert(ioq_config:is_valid_class(C)) || C <- Classes].
+
+
+check_undeclared_class(_) ->
+    ?_assert(not ioq_config:is_valid_class(search)).
+
+
+check_declared_class(_) ->
+    config:set(?IOQ2_CLASSES_CONFIG, "search", "1.0", false),
+    ?_assert(ioq_config:is_valid_class(search)).
+


### PR DESCRIPTION
    Allow dynamic classes in is_valid_class

    This adds support for dynamic classes in IOQ2. Before this change, the
    allowed set of classes was fixed and hardcoded, with no way for 3rd
    party IO traffic to be prioritized, and similarly, no way for 3rd party
    IO traffic to bypass IOQ based on config settings. This change switches
    to checking to see if there's a declared IO priority value in the
    classes config, and if so it is treated as a valid value. It's worth
    noting that because `ioq_config:set_class_config` uses the
    `is_valid_class` check, you must use `config:set` directly to declare an
    initial priority for the dynamic channel before being able to use the
    `ioq_config` helpers.
    
    This change was motivated by not being able to bypass search in the
    Dreyfus project, as it piggy-backed off of `interactive` and
    `view_update` channels. That was rectified in [1], and now Dreyfus uses
    the `search` IOQ channel. As that is not used in CouchDB directly, this
    commit adds the dynamic class support based off of config values, rather
    than specifically hardcoding search, so that it can be used by any 3rd
    party services running IO traffic through IOQ.
    
    [1] https://github.com/cloudant-labs/dreyfus/pull/46/commits/75d86c49c86f4e7e299d2d05a741c4ef68a144fb


TODO BEFORE MERGING:
  - [x] update IOQ2.md with details on how to declare dynamic channels.