### PR TITLE
Log from 0 is undefined

### DIFF
--- a/src/ioq_server.erl
+++ b/src/ioq_server.erl
@@ -474,6 +474,8 @@ upsert(Tab, Key, Incr) ->
         ets:insert(Tab, {Key, Incr})
     end.
 
+timebin(0) ->
+    0;
 timebin(V) ->
     trunc(10*math:log10(V)).
 


### PR DESCRIPTION
When running tests locally the delta between two calls to `erlang:monotonic_time()` converted to microseconds could be 0. In such case the test suite is crashing with the following exception:
```
undefined
*** context setup failed ***
**in function couch_mrview_util:get_view_index_state/5 (src/couch_mrview_util.erl, line 142)
in call from couch_mrview_util:get_view/4 (src/couch_mrview_util.erl, line 86)
in call from couch_mrview:query_view/6 (src/couch_mrview.erl, line 265)
in call from couchdb_file_compression_tests:refresh_index/1 (test/eunit/couchdb_file_compression_tests.erl, line 184)
in call from couchdb_file_compression_tests:setup/0 (test/eunit/couchdb_file_compression_tests.erl, line 38)
**throw:{{badarith,[{math,log10,[0],[]},
            {ioq_server,timebin,1,[{file,"src/ioq_server.erl"},{line,478}]},
            {ioq_server,update_histograms,3,
                        [{file,"src/ioq_server.erl"},{line,439}]},
            {ioq_server,handle_info,2,
                        [{file,"src/ioq_server.erl"},{line,151}]},
            {gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,616}]},
            {gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,686}]},
            {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]},
 {gen_server,call,
             [ioq_server,
              {request,<0.24173.0>,
                       {pread_iolist,1593621},
                       view_update,other,undefined,undefined,
                       -576460360535635480,undefined},
              infinity]}}


couchdb_file_compression_tests:118: should_compare_compression_methods (none > snappy > deflate_1 > deflate_9)...*failed*
in function couchdb_file_compression_tests:'-compact_db/1-fun-0-'/2 (test/eunit/couchdb_file_compression_tests.erl, line 194)
in call from couchdb_file_compression_tests:compare_compression_methods/1 (test/eunit/couchdb_file_compression_tests.erl, line 123)
**error:{assert,[{module,couchdb_file_compression_tests},
         {line,194},
         {expression,"DiskSizeBefore > DiskSizeAfter"},
         {expected,true},
         {value,false}]}
  output:<<"">>
```

This PR adds special handling of a case when `timebin/1` is called with delta equal to 0. In such case we always return the smallest possible bin (which is 0).