### PR TITLE
IOQ improvements

### DIFF
--- a/src/ioq_server.erl
+++ b/src/ioq_server.erl
@@ -527,8 +527,11 @@ save_to_db() ->
         ]},
         try
             fabric:update_doc(get_stats_dbname(), Doc, [])
-        catch error:database_does_not_exist ->
-            couch_log:debug("Missing IOQ stats db: ~s", [get_stats_dbname()])
+        catch
+            error:database_does_not_exist ->
+                couch_log:debug("Missing IOQ stats db: ~s", [get_stats_dbname()]);
+            error:conflict ->
+                couch_log:info("~p:save_to_db conflict saving ~p", [?MODULE, Doc])
         end
     after Timeout ->
         error_logger:error_report({?MODULE, "ets transfer failed"})

--- a/src/ioq_server.erl
+++ b/src/ioq_server.erl
@@ -474,7 +474,7 @@ upsert(Tab, Key, Incr) ->
         ets:insert(Tab, {Key, Incr})
     end.
 
-timebin(0) ->
+timebin(V) when V =< 0 ->
     0;
 timebin(V) ->
     trunc(10*math:log10(V)).


### PR DESCRIPTION
On recent versions of MacOS, a [bug](https://github.com/erlang/otp/commit/c772b107bcc220b5c7b9cd396ef825bc7e3204c6) prevents the use of monotonic time, which would explain how time might have seemingly gone backwards.

Also, handle conflicts when saving docs to the `stats` db.