### PR TITLE
4101 add iopriority

### DIFF
--- a/include/ioq.hrl
+++ b/include/ioq.hrl
@@ -39,7 +39,9 @@
     {db_update, 1.0},
     {view_update, 1.0},
     {other, 1.0},
-    {interactive, 1.0}
+    {interactive, 1.0},
+    {system, 1.0},
+    {search, 1.0}
 ]).
 
 
@@ -64,6 +66,8 @@
 -type io_priority() :: db_compact
     | db_update
     | interactive
+    | system
+    | search
     | internal_repl
     | other
     | customer
@@ -75,6 +79,7 @@
 -type dbname() :: binary() | dbcopy_string().
 -type group_id() :: any().
 -type io_dimensions() :: {io_priority(), dbname()}
-    | {view_io_priority(), dbname(), group_id()}.
+    | {view_io_priority(), dbname(), group_id()}
+    | {search, dbname(), group_id()}.
 -type ioq_request() :: #ioq_request{}.
 

--- a/priv/stats_descriptions.cfg
+++ b/priv/stats_descriptions.cfg
@@ -54,6 +54,14 @@
     {type, counter},
     {desc, <<"IO related to internal replication">>}
 ]}.
+{[couchdb, io_queue, search], [
+    {type, counter},
+    {desc, <<"IO routed to search engine">>}
+]}.
+{[couchdb, io_queue, system], [
+    {type, counter},
+    {desc, <<"IO related to internal system activities">>}
+]}.
 {[couchdb, io_queue, other], [
     {type, counter},
     {desc, <<"IO related to internal replication">>}
@@ -109,6 +117,14 @@
 {[couchdb, io_queue_bypassed, internal_repl], [
     {type, counter},
     {desc, <<"bypassed IO related to internal replication">>}
+]}.
+{[couchdb, io_queue_bypassed, search], [
+    {type, counter},
+    {desc, <<"bypassed IO routed to search engine">>}
+]}.
+{[couchdb, io_queue_bypassed, system], [
+    {type, counter},
+    {desc, <<"bypassed IO related to internal system activities">>}
 ]}.
 {[couchdb, io_queue_bypassed, other], [
     {type, counter},
@@ -189,6 +205,14 @@
 {[couchdb, io_queue2, internal_repl, count], [
     {type, counter},
     {desc, <<"IO related to internal replication">>}
+]}.
+{[couchdb, io_queue2, search, count], [
+    {type, counter},
+    {desc, <<"IO routed to search engine">>}
+]}.
+{[couchdb, io_queue2, system, count], [
+    {type, counter},
+    {desc, <<"IO related to internal system activities">>}
 ]}.
 {[couchdb, io_queue2, other, count], [
     {type, counter},

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,2 @@
+{cover_enabled, true}.
+{cover_print_enabled, true}.

--- a/src/ioq.erl
+++ b/src/ioq.erl
@@ -17,8 +17,21 @@
 -export([
     ioq2_enabled/0
 ]).
+-export([get_io_priority/0, set_io_priority/1, maybe_set_io_priority/1]).
 
 -define(APPS, [config, folsom, couch_stats, ioq]).
+
+set_io_priority(Priority) ->
+    erlang:put(io_priority, Priority).
+
+get_io_priority() ->
+    erlang:get(io_priority).
+
+maybe_set_io_priority(Priority) ->
+    case get_io_priority() of
+        undefined -> set_io_priority(Priority);
+        _ -> ok
+    end.
 
 start() ->
     lists:foldl(fun(App, _) -> application:start(App) end, ok, ?APPS).

--- a/src/ioq_server.erl
+++ b/src/ioq_server.erl
@@ -218,12 +218,18 @@ analyze_priority({db_update, Shard}) ->
     {db_update, channel_name(Shard)};
 analyze_priority({view_update, Shard, _GroupId}) ->
     {view_update, channel_name(Shard)};
+analyze_priority({search, Shard}) ->
+    {search, channel_name(Shard)};
+analyze_priority({search, Shard, _GroupId}) ->
+    {search, channel_name(Shard)};
 analyze_priority({db_compact, _Shard}) ->
     {db_compact, nil};
 analyze_priority({view_compact, _Shard, _GroupId}) ->
     {view_compact, nil};
 analyze_priority({internal_repl, _Shard}) ->
     {internal_repl, nil};
+analyze_priority({system, _Shard}) ->
+    {system, nil};
 analyze_priority({low, _Shard}) ->
     {low, nil};
 analyze_priority(_Else) ->
@@ -465,6 +471,10 @@ make_key(interactive, {pread_iolist, _}) ->
     <<"reads">>;
 make_key(interactive, {append_bin, _}) ->
     <<"writes">>;
+make_key(system, _) ->
+    <<"system">>;
+make_key(search, _) ->
+    <<"search">>;
 make_key(_, _) ->
     <<"other">>.
 
@@ -586,8 +596,51 @@ split(B, O, S, Acc) ->
 
 rw({pread_iolist, _}) ->
     reads;
+rw({pread_iolists, _}) ->
+    reads;
 rw({append_bin, _}) ->
     writes;
+rw({append_bins, _}) ->
+    writes;
+rw({append_bin, _, _}) ->
+    writes;
+rw(find_header) ->
+    reads;
+rw({write_header, _}) ->
+    writes;
+%% Search classes
+rw({open, _Peer, _Path, _Analyzer}) ->
+    reads;
+rw({disk_size, _Path}) ->
+    reads;
+rw({get_root_dir}) ->
+    reads;
+rw({await, _Min_Seq}) ->
+    reads;
+rw({commit, _New_Commit_Seq}) ->
+    reads;
+rw(info) ->
+    reads;
+rw(get_update_seq) ->
+    reads;
+rw({set_purge_seq, _Seq}) ->
+    reads;
+rw(get_purge_seq) ->
+    reads;
+rw({search, _Args}) ->
+    reads;
+rw({group1, _Query, _Group_By, _Refresh, _Sort, _Offset, _Limit}) ->
+    reads;
+rw({group2, _Args}) ->
+    reads;
+rw({delete, _Id}) ->
+    reads;
+rw({update, _Id, _Fields}) ->
+    writes;
+rw({analyze, _Analyzer, _Text}) ->
+    reads;
+rw(version) ->
+    reads;
 rw(_) ->
     unknown.
 

--- a/src/ioq_server2.erl
+++ b/src/ioq_server2.erl
@@ -577,10 +577,51 @@ time_delta(T1, T0) ->
 -spec rw(io_dimensions()) -> read_write().
 rw({pread_iolist, _}) ->
     reads;
+rw({pread_iolists, _}) ->
+    reads;
 rw({append_bin, _}) ->
+    writes;
+rw({append_bins, _}) ->
     writes;
 rw({append_bin, _, _}) ->
     writes;
+rw(find_header) ->
+    reads;
+rw({write_header, _}) ->
+    writes;
+%% Search classes
+rw({open, _Peer, _Path, _Analyzer}) ->
+    reads;
+rw({disk_size, _Path}) ->
+    reads;
+rw({get_root_dir}) ->
+    reads;
+rw({await, _Min_Seq}) ->
+    reads;
+rw({commit, _New_Commit_Seq}) ->
+    reads;
+rw(info) ->
+    reads;
+rw(get_update_seq) ->
+    reads;
+rw({set_purge_seq, _Seq}) ->
+    reads;
+rw(get_purge_seq) ->
+    reads;
+rw({search, _Args}) ->
+    reads;
+rw({group1, _Query, _Group_By, _Refresh, _Sort, _Offset, _Limit}) ->
+    reads;
+rw({group2, _Args}) ->
+    reads;
+rw({delete, _Id}) ->
+    reads;
+rw({update, _Id, _Fields}) ->
+    writes;
+rw({analyze, _Analyzer, _Text}) ->
+    reads;
+rw(version) ->
+    reads;
 rw(_) ->
     unknown.
 

--- a/test/ioq_config_tests.erl
+++ b/test/ioq_config_tests.erl
@@ -284,7 +284,7 @@ check_default_classes(_) ->
 
 
 check_undeclared_class(_) ->
-    ?_assert(not ioq_config:is_valid_class(search)).
+    ?_assert(not ioq_config:is_valid_class(external)).
 
 
 check_declared_class(_) ->


### PR DESCRIPTION
This is a companion PR to https://github.com/apache/couchdb/pull/4106 addressing https://github.com/apache/couchdb/issues/4101.

This PR adds the `system` io_class and also the new utility functions for setting and querying `io_priority`.