### PR TITLE
Add IOQ2 pid for search traffic

### DIFF
--- a/include/ioq.hrl
+++ b/include/ioq.hrl
@@ -11,13 +11,16 @@
 % the License.
 
 -define(DEFAULT_PRIORITY, 1.0).
+-define(DEFAULT_IOQ2_CONCURRENCY, 1).
 -define(BAD_MAGIC_NUM, -12341234).
 
 %% Dispatch Strategies
--define(DISPATCH_RANDOM, "random").
--define(DISPATCH_FD_HASH, "fd_hash").
--define(DISPATCH_SINGLE_SERVER, "single_server").
--define(DISPATCH_SERVER_PER_SCHEDULER, "server_per_scheduler").
+-define(DISPATCH_RANDOM, random).
+-define(DISPATCH_FD_HASH, fd_hash).
+-define(DISPATCH_SINGLE_SERVER, single_server).
+-define(DISPATCH_SERVER_PER_SCHEDULER, server_per_scheduler).
+
+-define(IOQ2_SEARCH_SERVER, ioq_server_search).
 
 %% Config Categories
 -define(SHARD_CLASS_SEPARATOR, "||").

--- a/src/ioq.erl
+++ b/src/ioq.erl
@@ -11,9 +11,9 @@
 % the License.
 
 -module(ioq).
--export([start/0, stop/0, call/3, call/4, set_disk_concurrency/1,
-    get_disk_queues/0, get_osproc_queues/0, get_osproc_requests/0,
-    get_disk_counters/0, get_disk_concurrency/0]).
+-export([start/0, stop/0, call/3, call/4, call_search/3,
+    set_disk_concurrency/1, get_disk_queues/0, get_osproc_queues/0,
+    get_osproc_requests/0, get_disk_counters/0, get_disk_concurrency/0]).
 -export([
     ioq2_enabled/0
 ]).
@@ -50,6 +50,12 @@ call(Fd, Msg, Priority) ->
     case ioq2_enabled() of
         false -> ioq_server:call(Fd, Msg, Priority);
         true  -> ioq_server2:call(Fd, Msg, Priority)
+    end.
+
+call_search(Fd, Msg, Priority) ->
+    case ioq2_enabled() of
+        false -> ioq_server:call(Fd, Msg, Priority);
+        true  -> ioq_server2:call_search(Fd, Msg, Priority)
     end.
 
 set_disk_concurrency(C) when is_integer(C), C > 0 ->

--- a/src/ioq_config.erl
+++ b/src/ioq_config.erl
@@ -50,6 +50,7 @@
     set_scale_factor/2,
     set_resize_limit/2,
     set_concurrency/2,
+    get_dispatch_strategy/0,
     set_dispatch_strategy/2
 ]).
 
@@ -87,6 +88,15 @@ set_concurrency(Value, Reason) when is_integer(Value) ->
     set_config(?IOQ2_CONFIG, "concurrency", integer_to_list(Value), Reason).
 
 
+get_dispatch_strategy() ->
+    case config:get("ioq2", "dispatch_strategy", undefined) of
+        undefined         -> ?DISPATCH_SERVER_PER_SCHEDULER;
+        DispatchStrategy0 -> list_to_atom(DispatchStrategy0)
+    end.
+
+
+set_dispatch_strategy(Value, Reason) when is_list(Value) ->
+    set_dispatch_strategy(list_to_existing_atom(Value), Reason);
 set_dispatch_strategy(Value, Reason) ->
     ErrorMsg = "Dispatch strategy must be one of "
         "random, fd_hash, server_per_scheduler, or single_server.",
@@ -97,7 +107,7 @@ set_dispatch_strategy(Value, Reason) ->
         ?DISPATCH_SERVER_PER_SCHEDULER -> ok;
         _                              -> throw({badarg, ErrorMsg})
     end,
-    config:set(?IOQ2_CONFIG, "dispatch_strategy", Value, Reason).
+    config:set(?IOQ2_CONFIG, "dispatch_strategy", atom_to_list(Value), Reason).
 
 
 set_db_config(DbName, Class, Value, Reason) when is_binary(DbName) ->

--- a/test/ioq_config_tests.erl
+++ b/test/ioq_config_tests.erl
@@ -231,7 +231,8 @@ check_simple_configs(_) ->
         {set_scale_factor, 3.14, "3.14"},
         {set_max_priority, 99999.99, "99999.99"},
         {set_enabled, true, "true"},
-        {set_dispatch_strategy, ?DISPATCH_FD_HASH, ?DISPATCH_FD_HASH}
+        {set_dispatch_strategy,
+            ?DISPATCH_FD_HASH, atom_to_list(?DISPATCH_FD_HASH)}
     ],
 
     Reason = "ioq_config_tests",


### PR DESCRIPTION
This PR adds a dedicated IOQ2 pid for search traffic such that traffic to an external search engine like Clouseau does not utilize the same pool of IOQ2 pids that normal couch_file database traffic utilizes, as that has proven to be error prone.

This also fixes a bug in the config listener not updating the IOQ1 server on config updates.