### PR TITLE
Add editors magic lines

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,4 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 {cover_enabled, true}.
 {cover_print_enabled, true}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,3 +1,5 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 WithProper = code:lib_dir(proper) /= {error, bad_name}.
 
 


### PR DESCRIPTION
Most of the code editors select syntax highlighting language based on file name extension. However, this approach doesn't work when the extension is not standard. For such cases, there are magic lines. Without the magic lines, files with unknown extensions require extra steps to enable syntax highlighting and auto-completion. This PR adds a magic line for Vim.