### PR TITLE
Quiet noisy tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.eunit
 .rebar
 ebin/

--- a/src/ioq_server2.erl
+++ b/src/ioq_server2.erl
@@ -851,11 +851,6 @@ test_simple_dedupe(St0) ->
         from = FromA,
         key = {Fd, Pos}
     },
-    _Request1B = Request0#ioq_request{
-        init_priority = Priority,
-        from = FromA,
-        key = {Fd, Pos}
-    },
     {noreply, St2, 0} = handle_call(Request0, FromA, St1),
     {noreply, St3, 0} = handle_call(Request0, FromB, St2),
     {reply, RespState, _St4, 0} = handle_call(get_state, FromA, St3),
@@ -925,7 +920,7 @@ test_auto_scale(#state{queue=HQ}=St0) ->
     {_, #ioq_request{init_priority=PriorityA2}} = hqueue:extract_max(HQ),
     Tests0 = [?_assertEqual(PriorityA, PriorityA2)],
     {_St, Tests} = lists:foldl(
-        fun(_N, {#state{iterations=I, resize_limit=RL}=StN0, TestsN}) ->
+        fun(_N, {#state{iterations=I}=StN0, TestsN}) ->
             ReqN = BaseReq#ioq_request{ref=make_ref()},
             ExpectedPriority = case I == 1 of
                 false -> PriorityA;

--- a/test/ioq_config_tests.erl
+++ b/test/ioq_config_tests.erl
@@ -35,8 +35,14 @@ config_update_test_() ->
         "Test config updates",
         {
             foreach,
-            fun() -> test_util:start_applications([config, couch_log, ioq]) end,
-            fun test_util:stop_applications/1,
+            fun() ->
+                meck:expect(couch_log, notice, fun(_, _) -> ok end),
+                test_util:start_applications([config, ioq])
+            end,
+            fun(Apps) ->
+                test_util:stop_applications(Apps),
+                meck:unload()
+            end,
             [
                 fun t_restart_config_listener/1,
                 fun t_update_ioq_config/1,
@@ -204,8 +210,14 @@ config_set_test_() ->
         "Test ioq_config setters",
         {
             foreach,
-            fun() -> test_util:start_applications([config, couch_log]) end,
-            fun(_) -> test_util:stop_applications([config, couch_log]) end,
+            fun() ->
+                meck:expect(couch_log, notice, fun(_, _) -> ok end),
+                test_util:start_applications([config])
+            end,
+            fun(_) ->
+                test_util:stop_applications([config]),
+                meck:unload()
+            end,
             [
                 fun check_simple_configs/1,
                 fun check_bypass_configs/1
@@ -268,8 +280,14 @@ valid_classes_test_() ->
         "Test ioq_config is_valid_class logic",
         {
             foreach,
-            fun() -> test_util:start_applications([config, couch_log]) end,
-            fun(_) -> test_util:stop_applications([config, couch_log]) end,
+            fun() ->
+                meck:expect(couch_log, notice, fun(_, _) -> ok end),
+                test_util:start_applications([config])
+            end,
+            fun(_) ->
+                test_util:stop_applications([config]),
+                meck:unload()
+            end,
             [
                 fun check_default_classes/1,
                 fun check_undeclared_class/1,

--- a/test/ioq_kv_tests.erl
+++ b/test/ioq_kv_tests.erl
@@ -122,7 +122,7 @@ random_key(#st{kvs=KVs}) ->
     Keys0 = dict:fetch_keys(KVs),
     Keys = lists:append(Keys0, [foo]),
     NumKeys = erlang:length(Keys),
-    KeyPos = random:uniform(NumKeys),
+    KeyPos = rand:uniform(NumKeys),
     lists:nth(KeyPos, Keys).
 
 cleanup() ->

--- a/test/ioq_tests.erl
+++ b/test/ioq_tests.erl
@@ -11,7 +11,6 @@
 % the License.
 
 -module(ioq_tests).
--compile(export_all).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("ioq/include/ioq.hrl").


### PR DESCRIPTION
- Git ignore .eunit directory
- Quiet noisy tests by mocking `couch_log`
- Fix compiler warnings
