### PR TITLE
Add a proper reshard ioq class

### DIFF
--- a/include/ioq.hrl
+++ b/include/ioq.hrl
@@ -44,7 +44,8 @@
     {other, 1.0},
     {interactive, 1.0},
     {system, 1.0},
-    {search, 1.0}
+    {search, 1.0},
+    {reshard, 0.001}
 ]).
 
 
@@ -72,6 +73,7 @@
     | system
     | search
     | internal_repl
+    | reshard
     | other
     | customer
     | db_meta

--- a/operator_guide.md
+++ b/operator_guide.md
@@ -46,6 +46,8 @@ that the mapping of IOQ classes to class priorities is not 1:1.
 | internal_repl | replication   | IO requests related to internal            |
 |               |               | replication.                               |
 |               |               |                                            |
+| reshard       | reshard       | IO requests related to resharding jobs     |
+|               |               |                                            |
 | low           | low           | IO requests related to requests made by    |
 |               |               | users via the http layer where the         |
 |               |               | "x-cloudant-priority: low" header is set.  |

--- a/priv/stats_descriptions.cfg
+++ b/priv/stats_descriptions.cfg
@@ -62,6 +62,10 @@
     {type, counter},
     {desc, <<"IO related to internal system activities">>}
 ]}.
+{[couchdb, io_queue, reshard], [
+    {type, counter},
+    {desc, <<"IO related to resharding jobs">>}
+]}.
 {[couchdb, io_queue, other], [
     {type, counter},
     {desc, <<"IO related to internal replication">>}
@@ -125,6 +129,10 @@
 {[couchdb, io_queue_bypassed, system], [
     {type, counter},
     {desc, <<"bypassed IO related to internal system activities">>}
+]}.
+{[couchdb, io_queue_bypassed, reshard], [
+    {type, counter},
+    {desc, <<"bypassed IO related to resharding jobs">>}
 ]}.
 {[couchdb, io_queue_bypassed, other], [
     {type, counter},
@@ -213,6 +221,10 @@
 {[couchdb, io_queue2, system, count], [
     {type, counter},
     {desc, <<"IO related to internal system activities">>}
+]}.
+{[couchdb, io_queue2, reshard, count], [
+    {type, counter},
+    {desc, <<"IO related to resharding jobs">>}
 ]}.
 {[couchdb, io_queue2, other, count], [
     {type, counter},

--- a/src/ioq_server.erl
+++ b/src/ioq_server.erl
@@ -228,6 +228,8 @@ analyze_priority({view_compact, _Shard, _GroupId}) ->
     {view_compact, nil};
 analyze_priority({internal_repl, _Shard}) ->
     {internal_repl, nil};
+analyze_priority({reshard, _Shard}) ->
+    {reshard, nil};
 analyze_priority({system, _Shard}) ->
     {system, nil};
 analyze_priority({low, _Shard}) ->
@@ -256,6 +258,8 @@ enqueue_request(#request{class = db_compact} = Req, State) ->
 enqueue_request(#request{class = view_compact} = Req, State) ->
     State#state{qC = update_queue(Req, State#state.qC, State#state.dedupe)};
 enqueue_request(#request{class = internal_repl} = Req, State) ->
+    State#state{qR = update_queue(Req, State#state.qR, State#state.dedupe)};
+enqueue_request(#request{class = reshard} = Req, State) ->
     State#state{qR = update_queue(Req, State#state.qR, State#state.dedupe)};
 enqueue_request(#request{class = low} = Req, State) ->
     State#state{qL = update_queue(Req, State#state.qL, State#state.dedupe)};
@@ -473,6 +477,8 @@ make_key(interactive, {append_bin, _}) ->
     <<"writes">>;
 make_key(system, _) ->
     <<"system">>;
+make_key(reshard, _) ->
+    <<"reshard">>;
 make_key(search, _) ->
     <<"search">>;
 make_key(_, _) ->

--- a/src/ioq_server2.erl
+++ b/src/ioq_server2.erl
@@ -776,6 +776,7 @@ queue_depths_test_() ->
         #ioq_request{user=Foo, class=view_update},
         #ioq_request{user=Foo, class=view_update},
         #ioq_request{user=Foo, class=view_update},
+        #ioq_request{user=Foo, class=reshard},
 
         #ioq_request{user=Bar, class=interactive},
         #ioq_request{user=Bar, class=db_update},
@@ -788,7 +789,7 @@ queue_depths_test_() ->
         {replication, 3},
         {low, 1},
         {channels, {[
-            {<<"foo">>, [2,1,4]},
+            {<<"foo">>, [3,1,4]},
             {<<"bar">>, [1,3,1]}
         ]}}
     ],
@@ -1028,7 +1029,7 @@ check_call(Server, Call, Priority) ->
 
 
 io_classes() -> [interactive, view_update, db_compact, view_compact,
-    internal_repl, other, db_meta].
+    internal_repl, other, db_meta, reshard].
 
 
 shards() ->

--- a/test/ioq_tests.erl
+++ b/test/ioq_tests.erl
@@ -55,7 +55,7 @@ check_call(Server, Call, Priority) ->
     ?_assertEqual({reply, Call}, ioq:call(Server, Call, Priority)).
 
 io_classes() -> [interactive, view_update, db_compact, view_compact,
-    internal_repl, other, search, system].
+    internal_repl, other, search, system, reshard].
 
 shards() ->
     [


### PR DESCRIPTION
This mirrors the upstream PR https://github.com/apache/couchdb/pull/4270

It roughly at the same priority level as the internal replicator. A a bit higher than compaction but lower than interactive.