### PR TITLE
Add ioq:bypass/2 API

### DIFF
--- a/src/ioq.erl
+++ b/src/ioq.erl
@@ -18,7 +18,7 @@
     ioq2_enabled/0
 ]).
 -export([get_io_priority/0, set_io_priority/1, maybe_set_io_priority/1]).
-
+-export([bypass/2]).
 -define(APPS, [config, couch_stats, ioq]).
 
 set_io_priority(Priority) ->
@@ -31,6 +31,12 @@ maybe_set_io_priority(Priority) ->
     case get_io_priority() of
         undefined -> set_io_priority(Priority);
         _ -> ok
+    end.
+
+bypass(Msg, Priority) ->
+    case ioq2_enabled() of
+        false -> ioq_server:bypass(Msg, Priority);
+        true  -> ioq_server2:bypass(Msg, Priority)
     end.
 
 start() ->


### PR DESCRIPTION
Given a message and a priority, return `true` if that operation would be bypassed. This is used by the parallel preads commit [1] with the cfile handle when we know the request would be bypassed by the IOQ.

If/when we figure out how to teach the IOQ server to call a regular MFA, as opposed to always sending a '$gen_call' message, we won't have a need for this and can remove this API.

While at it, do some minor test housekeeping and use the standard `?TDEF_FE` helper macro to remove the eunit `?_test/begin` boilerplate code.

[1] https://github.com/apache/couchdb/pull/5399