### PR TITLE
Make sure to handle `other` priority in ioq's new bypass/2 API

### DIFF
--- a/src/ioq_server2.erl
+++ b/src/ioq_server2.erl
@@ -519,7 +519,9 @@ enqueue_request(Req, #state{queue=HQ, waiters=Waiters}=State0) ->
 bypass(_Msg, {Class, _Shard}) ->
     config:get_boolean("ioq2.bypass", atom_to_list(Class), false);
 bypass(_Msg, {Class, _Shard0, _GroupId}) ->
-    config:get_boolean("ioq2.bypass", atom_to_list(Class), false).
+    config:get_boolean("ioq2.bypass", atom_to_list(Class), false);
+bypass(_Msg, _) ->
+    config:get_boolean("ioq2.bypass", "other", false).
 
 -spec add_request_dimensions(ioq_request(), io_dimensions()) -> ioq_request().
 add_request_dimensions(Request, {Class, Shard}) ->

--- a/test/ioq_config_tests.erl
+++ b/test/ioq_config_tests.erl
@@ -271,6 +271,13 @@ check_bypass_configs(_) ->
     config:set("ioq.bypass", "interactive", "true", false),
     ?assert(ioq:bypass({'$gen_call', fd, foo}, {interactive, Shard})),
     ?assertNot(ioq:bypass({'$gen_call', fd, foo}, {db_commpact, Shard})),
+    % check other
+    ?assertNot(ioq:bypass({'$gen_call', fd, bar}, undefined)),
+    ?assertNot(ioq:bypass({'$gen_call', fd, bar}, [some, junk, {}])),
+    config:set("ioq.bypass", "other", "true", false),
+    ?assert(ioq:bypass({'$gen_call', fd, bar}, undefined)),
+    ?assert(ioq:bypass({'$gen_call', fd, bar}, [some, junk, {}])),
+    config:delete("ioq.bypass", "other", false),
 
     % ioq 2
     config:set("ioq2", "enabled", "true", false),
@@ -280,6 +287,13 @@ check_bypass_configs(_) ->
 
     ?assert(ioq:bypass({'$gen_call', fd, foo}, {interactive, Shard})),
     ?assertNot(ioq:bypass({'$gen_call', fd, foo}, {db_commpact, Shard})),
+    % check other
+    ?assertNot(ioq:bypass({'$gen_call', fd, bar}, undefined)),
+    ?assertNot(ioq:bypass({'$gen_call', fd, bar}, [some, junk, {}])),
+    config:set("ioq2.bypass", "other", "true", false),
+    ?assert(ioq:bypass({'$gen_call', fd, bar}, undefined)),
+    ?assert(ioq:bypass({'$gen_call', fd, bar}, [some, junk, {}])),
+    config:delete("ioq2.bypass", "other", false),
 
     config:delete("ioq2", "enabled", false),
     config:delete("ioq.bypass", "interactive", false),


### PR DESCRIPTION
It's a new API to check if the request would be bypassed by the IOQ. IOQ2 server didn't handle that clause properly and it would throw function_clause errors as a result.

IOQ1 apparently handles any value for the priority so we ensure to do the same. Normally it would be `undefined` though but we'll go with IOQ1's approach and accept any junk there since it's the "other" category.