### PR TITLE
Add error handling for `noproc`

### DIFF
--- a/src/ioq_server.erl
+++ b/src/ioq_server.erl
@@ -78,7 +78,12 @@ call(Fd, Msg, Priority) ->
                 class = Class,
                 t0 = erlang:monotonic_time()
             },
-            gen_server:call(?MODULE, Request, infinity)
+            try
+                gen_server:call(?MODULE, Request, infinity)
+            catch
+                exit:{noproc, _} ->
+                    gen_server:call(Fd, Msg, infinity)
+            end
     end.
 
 bypass(_Msg, Priority) ->

--- a/src/ioq_server2.erl
+++ b/src/ioq_server2.erl
@@ -118,7 +118,12 @@ call_int(Fd, Msg, Dimensions, IOType) ->
             },
             Req = add_request_dimensions(Req0, Dimensions),
             Server = ioq_server(Req, IOType),
-            gen_server:call(Server, Req, infinity)
+            try
+                gen_server:call(Server, Req, infinity)
+            catch
+                exit:{noproc, _} ->
+                    gen_server:call(Fd, Msg, infinity)
+            end
     end.
 
 ioq_server(#ioq_request{}, search) ->


### PR DESCRIPTION
Add error handling to avoid the following error:

```bash
$ make eunit apps=couch suites=couch_btree_prop_tests
...
**error:{assertMatch,[{module,couch_btree_prop_tests},
              {line,35},
              {comment,"Failed property test 'prop_btree_'"},
              {expression,"proper : quickcheck ( ? MODULE : F ( ) , [ { to_file , user } , { start_size , 2 } , { numtests , 3000 } , long_result ] )"},
              {pattern,"true"},
              {value,[[{set,{var,1},
                            {call,couch_btree_prop_tests,query_modify,
                                  [[551,502],[{882,c},{948,a}],[]]}}]]}]}
```

Related PR:
- https://github.com/apache/couchdb/pull/5635
- https://github.com/apache/couchdb/pull/5636